### PR TITLE
wifi: Merge QC wifi dual interface changes

### DIFF
--- a/wifi/1.0-legacy/Android.mk
+++ b/wifi/1.0-legacy/Android.mk
@@ -36,6 +36,9 @@ endif
 ifdef WIFI_HIDL_FEATURE_DISABLE_AP_MAC_RANDOMIZATION
 LOCAL_CPPFLAGS += -DWIFI_HIDL_FEATURE_DISABLE_AP_MAC_RANDOMIZATION
 endif
+ifdef QC_WIFI_HIDL_FEATURE_DUAL_AP
+LOCAL_CPPFLAGS += -DQC_WIFI_HIDL_FEATURE_DUAL_AP
+endif
 # Allow implicit fallthroughs in wifi_legacy_hal.cpp until they are fixed.
 LOCAL_CFLAGS += -Wno-error=implicit-fallthrough
 LOCAL_SRC_FILES := \

--- a/wifi/1.0-legacy/wifi_chip.cpp
+++ b/wifi/1.0-legacy/wifi_chip.cpp
@@ -21,6 +21,7 @@
 #include <cutils/properties.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
+#include <net/if.h>
 
 #include "hidl_return_util.h"
 #include "hidl_struct_util.h"
@@ -626,6 +627,8 @@ void WifiChip::invalidateAndRemoveAllIfaces() {
     invalidateAndClearAll(nan_ifaces_);
     invalidateAndClearAll(p2p_ifaces_);
     invalidateAndClearAll(sta_ifaces_);
+    invalidateAndClearAll(created_ap_ifaces_);
+    invalidateAndClearAll(created_sta_ifaces_);
     // Since all the ifaces are invalid now, all RTT controller objects
     // using those ifaces also need to be invalidated.
     for (const auto& rtt : rtt_controllers_) {
@@ -805,10 +808,24 @@ std::pair<WifiStatus, sp<IWifiApIface>> WifiChip::createApIfaceInternal() {
     if (!canCurrentModeSupportIfaceOfTypeWithCurrentIfaces(IfaceType::AP)) {
         return {createWifiStatus(WifiStatusCode::ERROR_NOT_AVAILABLE), {}};
     }
+
+    bool iface_created = false;
     std::string ifname = allocateApIfaceName();
+    if (!if_nametoindex(ifname.c_str())) {
+        legacy_hal::wifi_error legacy_status =
+            legacy_hal_.lock()->QcAddInterface(getWlanIfaceName(0), ifname,
+                                               (uint32_t)IfaceType::AP);
+        if (legacy_status != legacy_hal::WIFI_SUCCESS) {
+            LOG(ERROR) << "Failed to add interface: " << ifname << " "
+                       << legacyErrorToString(legacy_status);
+            return {createWifiStatusFromLegacyError(legacy_status), {}};
+        }
+        iface_created = true;
+    }
     sp<WifiApIface> iface =
         new WifiApIface(ifname, legacy_hal_, iface_util_, feature_flags_);
     ap_ifaces_.push_back(iface);
+    if (iface_created) created_ap_ifaces_.push_back(iface);
     for (const auto& callback : event_cb_handler_.getCallbacks()) {
         if (!callback->onIfaceAdded(IfaceType::AP, ifname).isOk()) {
             LOG(ERROR) << "Failed to invoke onIfaceAdded callback";
@@ -839,6 +856,16 @@ WifiStatus WifiChip::removeApIfaceInternal(const std::string& ifname) {
     const auto iface = findUsingName(ap_ifaces_, ifname);
     if (!iface.get()) {
         return createWifiStatus(WifiStatusCode::ERROR_INVALID_ARGS);
+    }
+
+    if (findUsingName(created_ap_ifaces_, ifname) != nullptr) {
+        legacy_hal::wifi_error legacy_status =
+            legacy_hal_.lock()->QcRemoveInterface(getWlanIfaceName(0), ifname);
+        if (legacy_status != legacy_hal::WIFI_SUCCESS) {
+            LOG(ERROR) << "Failed to remove interface: " << ifname << " "
+                       << legacyErrorToString(legacy_status);
+        }
+        invalidateAndClear(created_ap_ifaces_, iface);
     }
     // Invalidate & remove any dependent objects first.
     // Note: This is probably not required because we never create
@@ -952,9 +979,22 @@ std::pair<WifiStatus, sp<IWifiStaIface>> WifiChip::createStaIfaceInternal() {
     if (!canCurrentModeSupportIfaceOfTypeWithCurrentIfaces(IfaceType::STA)) {
         return {createWifiStatus(WifiStatusCode::ERROR_NOT_AVAILABLE), {}};
     }
+    bool iface_created = false;
     std::string ifname = allocateStaIfaceName();
+    if (!if_nametoindex(ifname.c_str())) {
+        legacy_hal::wifi_error legacy_status =
+            legacy_hal_.lock()->QcAddInterface(getWlanIfaceName(0), ifname,
+                                               (uint32_t)IfaceType::STA);
+        if (legacy_status != legacy_hal::WIFI_SUCCESS) {
+            LOG(ERROR) << "Failed to add interface: " << ifname << " "
+                       << legacyErrorToString(legacy_status);
+            return {createWifiStatusFromLegacyError(legacy_status), {}};
+        }
+        iface_created = true;
+    }
     sp<WifiStaIface> iface = new WifiStaIface(ifname, legacy_hal_, iface_util_);
     sta_ifaces_.push_back(iface);
+    if (iface_created) created_sta_ifaces_.push_back(iface);
     for (const auto& callback : event_cb_handler_.getCallbacks()) {
         if (!callback->onIfaceAdded(IfaceType::STA, ifname).isOk()) {
             LOG(ERROR) << "Failed to invoke onIfaceAdded callback";
@@ -985,6 +1025,15 @@ WifiStatus WifiChip::removeStaIfaceInternal(const std::string& ifname) {
     const auto iface = findUsingName(sta_ifaces_, ifname);
     if (!iface.get()) {
         return createWifiStatus(WifiStatusCode::ERROR_INVALID_ARGS);
+    }
+    if (findUsingName(created_sta_ifaces_, ifname) != nullptr) {
+        legacy_hal::wifi_error legacy_status =
+            legacy_hal_.lock()->QcRemoveInterface(getWlanIfaceName(0), ifname);
+        if (legacy_status != legacy_hal::WIFI_SUCCESS) {
+            LOG(ERROR) << "Failed to remove interface: " << ifname << " "
+                       << legacyErrorToString(legacy_status);
+        }
+        invalidateAndClear(created_sta_ifaces_, iface);
     }
     // Invalidate & remove any dependent objects first.
     invalidateAndRemoveDependencies(ifname);

--- a/wifi/1.0-legacy/wifi_chip.h
+++ b/wifi/1.0-legacy/wifi_chip.h
@@ -269,6 +269,9 @@ class WifiChip : public V1_3::IWifiChip {
     hidl_callback_util::HidlCallbackHandler<V1_2::IWifiChipEventCallback>
         event_cb_handler_;
 
+    std::vector<sp<WifiApIface>> created_ap_ifaces_;
+    std::vector<sp<WifiStaIface>> created_sta_ifaces_;
+
     DISALLOW_COPY_AND_ASSIGN(WifiChip);
 };
 

--- a/wifi/1.0-legacy/wifi_feature_flags.cpp
+++ b/wifi/1.0-legacy/wifi_feature_flags.cpp
@@ -79,14 +79,28 @@ constexpr ChipModeId kMainModeId = chip_mode_ids::kV3;
 #      define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{P2P}, 1}}
 #    endif
 #  else
-#    ifdef WIFI_HIDL_FEATURE_AWARE
-//     (1 STA + 1 AP) or (1 STA + 1 of (P2P or NAN))
-#      define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
-                                              {{{STA}, 1}, {{P2P, NAN}, 1}}
+#    ifdef QC_WIFI_HIDL_FEATURE_DUAL_AP
+#      ifdef WIFI_HIDL_FEATURE_AWARE
+//       (1 STA + 1 AP) or (1 STA + 1 of (P2P or NAN)) or (2 AP)
+#        define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
+                                                {{{STA}, 1}, {{P2P, NAN}, 1}},\
+                                                {{{AP}, 2}}
+#      else
+//       (1 STA + 1 AP) or (1 STA + 1 P2P) or (2 AP)
+#        define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
+                                                {{{STA}, 1}, {{P2P}, 1}},\
+                                                {{{AP}, 2}}
+#      endif
 #    else
-//     (1 STA + 1 AP) or (1 STA + 1 P2P)
-#      define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
-                                              {{{STA}, 1}, {{P2P}, 1}}
+#      ifdef WIFI_HIDL_FEATURE_AWARE
+//       (1 STA + 1 AP) or (1 STA + 1 of (P2P or NAN))
+#        define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
+                                                {{{STA}, 1}, {{P2P, NAN}, 1}}
+#      else
+//       (1 STA + 1 AP) or (1 STA + 1 P2P)
+#        define WIFI_HAL_INTERFACE_COMBINATIONS {{{STA}, 1}, {{AP}, 1}},\
+                                                {{{STA}, 1}, {{P2P}, 1}}
+#      endif
 #    endif
 #  endif
 #else

--- a/wifi/1.0-legacy/wifi_legacy_hal.cpp
+++ b/wifi/1.0-legacy/wifi_legacy_hal.cpp
@@ -1415,6 +1415,35 @@ WifiLegacyHal::getGscanCachedResults(const std::string& iface_name) {
     return {status, std::move(cached_scan_results)};
 }
 
+wifi_error WifiLegacyHal::QcAddInterface(const std::string& iface_name,
+                                         const std::string& new_ifname,
+                                         uint32_t type) {
+    wifi_error status = global_func_table_.wifi_add_or_remove_virtual_intf(
+                           getIfaceHandle(iface_name),
+                           new_ifname.c_str(), type, true);
+
+    if (status == WIFI_SUCCESS) {
+        // refresh list of handlers now.
+        iface_name_to_handle_.clear();
+        status = retrieveIfaceHandles();
+    }
+    return status;
+}
+
+wifi_error WifiLegacyHal::QcRemoveInterface(const std::string& iface_name,
+                                            const std::string& ifname) {
+    wifi_error status =  global_func_table_.wifi_add_or_remove_virtual_intf(
+                             getIfaceHandle(iface_name),
+                             ifname.c_str(), 0, false);
+
+    if (status == WIFI_SUCCESS) {
+        // refresh list of handlers now.
+        iface_name_to_handle_.clear();
+        status = retrieveIfaceHandles();
+    }
+    return status;
+}
+
 void WifiLegacyHal::invalidate() {
     global_handle_ = nullptr;
     iface_name_to_handle_.clear();

--- a/wifi/1.0-legacy/wifi_legacy_hal.h
+++ b/wifi/1.0-legacy/wifi_legacy_hal.h
@@ -367,6 +367,13 @@ class WifiLegacyHal {
     wifi_error setCountryCode(const std::string& iface_name,
                               std::array<int8_t, 2> code);
 
+    wifi_error QcAddInterface(const std::string& iface_name,
+                              const std::string& new_ifname,
+                              uint32_t type);
+    wifi_error QcRemoveInterface(const std::string& iface_name,
+                                 const std::string& ifname);
+
+
    private:
     // Retrieve interface handles for all the available interfaces.
     wifi_error retrieveIfaceHandles();


### PR DESCRIPTION
wifi: Fetch softap interface name for creating ap_iface operations.

softap interface name could varry from platform to platform and
may need for addiitional features. This commit gets softap interface
name by property_get on "persist.vendor.wifi.softap.interface".
If not set, it will fall back to use either of available interface
in "wifi.interface" or "wifi.concurrent.interface".

This property can either be set via .rc files or at runtime by any
module.

CRs-Fixed: 2243203
Change-Id: Iec1684f6cdf8963e71bc0c40ca296ac6a79472ee

wifi: Add provision to create/remove dynamic interface(s).

This commit does following:
 - Add/Remove softap interface at runtime, if needed.
 - Use wlan.concurrent.interface as default softap interface.
 - Add build time support to enable SAP+SAP feature using
   QC_WIFI_HIDL_FEATURE_DUAL_AP flag. if enabled use wlan.interface
   as second SAP interface.

Change-Id: Icde3d54eda0f142e20f33cdb7ed95152eeee0bec
CRs-Fixed: 2257197

wifi: Add logic to create secondary interface for STA mode too.

Previously we introduced dynamic interface create/remove logic for
SAP interface where wlan.concurrent.interface was given first
preference for SAP interface.

Remove this preference and fallback to use the default order of
choosing interface names. Also add create/remove logic for secondary
interface in STA mode too.

Change-Id: Iec5c4492096327a18e67f5129736a9bd3c8533f0
CRs-Fixed: 2268421